### PR TITLE
Add allow unauthenticated for apt while installing packages

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,6 +16,7 @@
         name: "{{ item }}"
         state: present
         update_cache: yes
+        allow_unauthenticated: yes
         cache_valid_time: "{{ apt_cache_valid_time | default(omit) }}"
       with_items: "{{ mongodb_packages }}"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -17,6 +17,7 @@
         state: present
         update_cache: yes
         allow_unauthenticated: yes
+        force: yes
         cache_valid_time: "{{ apt_cache_valid_time | default(omit) }}"
       with_items: "{{ mongodb_packages }}"
 


### PR DESCRIPTION
Due to issue
```
(item=[u'mongodb-org-shell=3.2.21', u'mongodb-org-tools=3.2.21']) => {"cache_update_time": 1583310859, "cache_updated": false, "changed": false, "item": ["mongodb-org-shell=3.2.21", "mongodb-org-tools=3.2.21"], "msg": "'/usr/bin/apt-get -y -o \"Dpkg::Options::=--force-confdef\" -o \"Dpkg::Options::=--force-confold\"     install 'mongodb-org-shell=3.2.21' 'mongodb-org-tools=3.2.21'' failed: E: There are problems and -y was used without --force-yes\n", "rc": 100, "stderr": "E: There are problems and -y was used without --force-yes\n", "stderr_lines": ["E: There are problems and -y was used without --force-yes"], "stdout": "Reading package lists...\nBuilding dependency tree...\nReading state information...\nThe following NEW packages will be installed:\n  mongodb-org-shell mongodb-org-tools\n0 upgraded, 2 newly installed, 0 to remove and 90 not upgraded.\nNeed to get 36.7 MB of archives.\nAfter this operation, 157 MB of additional disk space will be used.\nWARNING: The following packages cannot be authenticated!\n  mongodb-org-shell mongodb-org-tools\n", "stdout_lines": ["Reading package lists...", "Building dependency tree...", "Reading state information...", "The following NEW packages will be installed:", "  mongodb-org-shell mongodb-org-tools", "0 upgraded, 2 newly installed, 0 to remove and 90 not upgraded.", "Need to get 36.7 MB of archives.", "After this operation, 157 MB of additional disk space will be used.", "WARNING: The following packages cannot be authenticated!", "  mongodb-org-shell mongodb-org-tools"]}
```